### PR TITLE
fix: map images format to png for export_tool endpoint

### DIFF
--- a/backend/routers/export.py
+++ b/backend/routers/export.py
@@ -131,12 +131,14 @@ async def export_ppt_file(
             )
         else:
             # 调用 export_tool 服务进行导出
+            # 前端使用 "images" 表示图片导出，export_tool 端点为 "png"
+            export_format = "png" if request.format == "images" else request.format
             logger.info(f"Calling export_tool service for {request.format} export")
-            
+
             try:
                 file_data, filename = await export_client.export(
                     slides_html=slides_html,
-                    format=request.format,
+                    format=export_format,
                     title=safe_title
                 )
             except Exception as e:


### PR DESCRIPTION
## Summary
- Fix export images returning 404 by mapping "images" format to "png" before calling export_tool
- 
## Problem
When exporting slides as images, the frontend sends `format: "images"` to the backend.
The backend passes it directly to export_tool, requesting `/api/export_tool/images`,
but export_tool only has a `/png` endpoint, resulting in a 404 error.

## Fix
Added format mapping in `backend/routers/export.py`: `"images"` → `"png"` before calling export_tool service.