### PR TITLE
新增图片搜索与自动嵌入功能

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,4 @@ dist-ssr
 
 # Docker volumes
 workspace/
+ppt_workspace/

--- a/backend/api_server.py
+++ b/backend/api_server.py
@@ -15,6 +15,7 @@ import json
 import uuid
 import logging
 import asyncio
+import tempfile
 from datetime import datetime
 from pathlib import Path
 from typing import Optional, List, Dict, Any
@@ -54,6 +55,7 @@ from services.llm import call_llm_api, call_llm_api_stream
 from services.search import (
     generate_search_queries,
     execute_search,
+    search_and_download_images,
     stream_search_thinking,
     stream_deep_thinking
 )
@@ -67,7 +69,8 @@ from services.task_planner import (
 from services.ppt_generator import (
     create_tool_call,
     parse_num_pages,
-    run_slide_design_agent
+    run_slide_design_agent,
+    replace_image_placeholders,
 )
 from services.resource_inliner import inline_all_resources
 
@@ -206,6 +209,8 @@ async def stream_ppt_generation(
                 "deep_thinking_content": existing_session.deep_thinking_content or "",
                 "supplement_data": existing_session.supplement_data or {},
                 "conversation_id": existing_session.conversation_id or conversation_id,
+                "image_results": [],
+                "workspace_dir": str(Path(Config.WORKSPACE_BASE) / session_id),
             }
             # 更新任务状态为 running
             await crud.update_session(db, session_id, task_status="running")
@@ -224,6 +229,8 @@ async def stream_ppt_generation(
                 "deep_thinking_content": "",
                 "supplement_data": supplement_data or {},
                 "conversation_id": conversation_id,
+                "image_results": [],
+                "workspace_dir": str(Path(Config.WORKSPACE_BASE) / session_id),
             }
     else:
         # 没有数据库连接时使用临时会话（兜底）
@@ -235,6 +242,8 @@ async def stream_ppt_generation(
             "deep_thinking_content": "",
             "supplement_data": supplement_data or {},
             "conversation_id": conversation_id,
+            "image_results": [],
+            "workspace_dir": str(Path(Config.WORKSPACE_BASE) / session_id),
         }
     
     # 如果提供了 supplement_data，更新会话（即使是空字典也要更新）
@@ -555,9 +564,14 @@ async def stream_ppt_generation(
             }
             yield f"data: {json.dumps(search_start_data, ensure_ascii=False)}\n\n"
             
-            # 执行搜索
-            results = await execute_search(query)
+            # 执行文字搜索和图片搜索（并行）
+            search_task = execute_search(query)
+            image_task = search_and_download_images(query, session["workspace_dir"])
+            results, image_results = await asyncio.gather(search_task, image_task)
             all_search_results.extend(results)
+            session["image_results"].extend(image_results)
+            if image_results:
+                logger.info(f"Found {len(image_results)} images for query: {query}")
             
             # 发送每个搜索结果
             for result in results[:]:
@@ -831,6 +845,8 @@ async def stream_ppt_generation(
             supplement_data=session["supplement_data"],
             num_pages=actual_num_pages,
             powerpoint_type=powerpoint_type,
+            image_results=session.get("image_results", []),
+            workspace_dir=session.get("workspace_dir", ""),
         ):
             event_type = event.get("type")
 
@@ -839,6 +855,14 @@ async def stream_ppt_generation(
                 html_content = event["html_content"]
                 description = event.get("description", f"第 {slide_count} 页")
                 
+                # 替换图片占位符（{{img_N}}）和假 URL 为本地图片的 base64
+                try:
+                    html_content = replace_image_placeholders(
+                        html_content, session.get("image_results", [])
+                    )
+                except Exception as e:
+                    logger.error(f"[Stage 7] Failed to replace image placeholders for slide {slide_count}: {e}")
+
                 # 内联外部资源（图片等）
                 try:
                     logger.info(f"[Stage 7] Inlining resources for slide {slide_count}...")

--- a/backend/deeppresenter/deeppresenter/roles/SlideDesign.yaml
+++ b/backend/deeppresenter/deeppresenter/roles/SlideDesign.yaml
@@ -37,7 +37,11 @@ system:
 
     think工具是详细计划、决策过程或对当前状态以及下一步做什么的个人思考空间，你的解释是给用户看的。在调用`initialize_slide`或`insert_slides`之前，必须向用户简要说明你的意图。注意，think对用户不可见，所以在调用think工具后，你需要向用户简要说明你的意图或下一步行动。
 
-    只能在初始化幻灯片设计之前搜索图片。
+    ⚠️ 图片素材已在 markdown 文件的"可用图片素材"章节中提供，使用 {{img_N}} 占位符引用。
+    在 HTML 中使用图片时，必须使用 <img> 标签，将 {{img_N}} 写入 src 属性，例如：<img src="{{img_1}}" alt="描述">
+    ⛔ 严禁使用 CSS background-image: url() 引用图片（导出 PPTX 时会丢失），必须用 <img> 标签。
+    封面背景图请用绝对定位的 <img> 实现，例如：<img src="{{img_1}}" style="position:absolute;top:0;left:0;width:100%;height:100%;object-fit:cover;z-index:0;">，然后在其上方叠加半透明遮罩 div 和文字内容。
+    严禁编造任何图片 URL（如 example.com 等虚假地址），只能使用 {{img_N}} 占位符。
 
 
 
@@ -181,7 +185,9 @@ system:
       - 封面幻灯片应有固定的宽度1280px和高度720px。
       
     6. 背景图片
-      - 只有一张图片，带有不透明/半透明遮罩，设置为background-image。
+      - 使用绝对定位的 <img> 标签实现全屏背景图（不要使用 CSS background-image），示例：
+        <img src="{{img_1}}" style="position:absolute;top:0;left:0;width:100%;height:100%;object-fit:cover;z-index:0;">
+        然后在其上方叠加一个半透明遮罩 div（z-index:1）和文字内容（z-index:2）。
 
     ### 内容页的样式规则
     - 通常，使用相同的颜色/字体调色板与前一页保持一致的设计。
@@ -220,7 +226,12 @@ system:
       - 数据可以参考在线图表组件，样式应与主题一致。当有许多数据图表时，遵循Bento Grid布局设计风格。
       
     6. 图像
-      除非要求，否则不强制要求每页都有图像。谨慎使用图像。不要使用不相关或纯粹装饰性的图像。
+      如果 markdown 文件中提供了"可用图片素材"，应积极在合适的幻灯片中使用。
+      使用 {{img_N}} 占位符引用图片，必须使用 <img> 标签，例如 <img src="{{img_1}}" alt="描述">。
+      ⛔ 严禁使用 CSS background-image: url() 引用图片（导出 PPTX 时会丢失）。
+      封面页背景图请用绝对定位的 <img> 标签 + 半透明遮罩 div 实现（参见封面页规则）。
+      内容页可在相关内容旁配图以增强视觉效果。
+      严禁编造任何图片 URL，只能使用 {{img_N}} 占位符。
       唯一性：每个图像必须在整个演示文稿中是唯一的。不要重复使用已经在先前幻灯片中使用的图像。
       质量：优先考虑清晰、高分辨率、无水印、无长文本的图像。
       大小：避免小于幻灯片面积15%的图像。如果需要logo/emblem，使用文本如"Your Logo"或相关图标代替。

--- a/backend/services/ppt_generator.py
+++ b/backend/services/ppt_generator.py
@@ -4,8 +4,10 @@ PPTAgent PPT 生成服务模块
 提供 PPT 生成核心功能
 """
 
+import base64
 import json
 import logging
+import re
 import tempfile
 from datetime import datetime
 from pathlib import Path
@@ -76,6 +78,69 @@ async def generate_slide_thinking(slide_count: int, topic: str) -> Optional[str]
         return None
 
 
+def _image_to_data_uri(local_path: str) -> Optional[str]:
+    """将本地图片文件转为 base64 data URI"""
+    try:
+        path = Path(local_path)
+        if not path.exists():
+            return None
+        data = path.read_bytes()
+        ext = path.suffix.lower().lstrip(".")
+        mime = {"jpg": "image/jpeg", "jpeg": "image/jpeg", "png": "image/png",
+                "webp": "image/webp", "gif": "image/gif"}.get(ext, "image/jpeg")
+        b64 = base64.b64encode(data).decode()
+        return f"data:{mime};base64,{b64}"
+    except Exception as e:
+        logger.warning(f"Failed to convert image to data URI: {local_path}: {e}")
+        return None
+
+
+def replace_image_placeholders(html: str, image_results: List[Dict]) -> str:
+    """替换 HTML 中的图片占位符和假 URL 为本地图片的 base64 data URI
+
+    处理策略（按优先级）：
+    1. 替换 {{img_N}} 占位符为对应图片的 base64
+    2. 替换 example.com 等虚假 URL 为可用图片的 base64
+    3. 替换其他无法访问的外部图片 URL 为可用图片的 base64
+    """
+    if not image_results:
+        return html
+
+    # 构建占位符 → data_uri 映射
+    placeholder_map = {}
+    data_uris = []
+    for i, img in enumerate(image_results):
+        local_path = img.get("local_path", "")
+        data_uri = _image_to_data_uri(local_path)
+        if data_uri:
+            placeholder_map[f"{{{{img_{i + 1}}}}}"] = data_uri
+            data_uris.append(data_uri)
+
+    if not data_uris:
+        return html
+
+    # 第一步：替换占位符 {{img_N}}
+    for placeholder, data_uri in placeholder_map.items():
+        html = html.replace(placeholder, data_uri)
+
+    # 第二步：替换假 URL（example.com 等明显的占位地址）
+    fake_url_pattern = re.compile(
+        r'src="(https?://(?:example\.com|placeholder\.com|via\.placeholder\.com|placehold\.it|picsum\.photos|dummyimage\.com)[^"]*)"'
+    )
+    used_idx = 0
+    def _replace_fake(match):
+        nonlocal used_idx
+        if used_idx < len(data_uris):
+            replacement = data_uris[used_idx]
+            used_idx += 1
+            return f'src="{replacement}"'
+        return match.group(0)
+
+    html = fake_url_pattern.sub(_replace_fake, html)
+
+    return html
+
+
 async def run_slide_design_agent(
     topic: str,
     outline_content: str,
@@ -84,6 +149,8 @@ async def run_slide_design_agent(
     supplement_data: dict,
     num_pages: int,
     powerpoint_type: str = "16:9 Widescreen",
+    image_results: Optional[List[Dict]] = None,
+    workspace_dir: Optional[str] = None,
 ) -> AsyncGenerator[dict, None]:
     """运行 SlideDesign agent 生成 PPT"""
     
@@ -108,10 +175,26 @@ async def run_slide_design_agent(
             snippet = result.get("snippet", "")[:200]
             search_summary += f"{i}. {title}\n   {snippet}\n\n"
         
-        # 创建临时工作空间
-        workspace = Path(tempfile.mkdtemp(prefix="ppt_"))
+        # 使用传入的 workspace 或创建临时工作空间
+        if workspace_dir:
+            workspace = Path(workspace_dir)
+            workspace.mkdir(parents=True, exist_ok=True)
+        else:
+            workspace = Path(tempfile.mkdtemp(prefix="ppt_"))
         md_file = workspace / "manuscript.md"
-        
+
+        # 构建图片素材章节（使用占位符）
+        image_section = ""
+        if image_results:
+            image_section = "\n## 可用图片素材\n以下图片已验证可用。在 HTML 的 <img> 标签中，使用 {{img_N}} 作为 src 的值。\n\n"
+            for i, img in enumerate(image_results, 1):
+                desc = img.get("description", "图片") or "图片"
+                w = img.get("width", 0)
+                h = img.get("height", 0)
+                image_section += f"{i}. {{{{img_{i}}}}} — {desc} ({w}×{h})\n"
+            image_section += "\n示例：<img src=\"{{img_1}}\" alt=\"描述\">\n\n"
+            logger.info(f"Added {len(image_results)} image placeholders to markdown")
+
         md_content = f"""# {topic}
 
 ## PPT大纲
@@ -125,7 +208,7 @@ async def run_slide_design_agent(
 ## 深度分析
 
 {deep_thinking_content[:2000] if deep_thinking_content else '无'}
-"""
+{image_section}"""
         md_file.write_text(md_content, encoding="utf-8")
         logger.info(f"Created markdown file at: {md_file}")
         
@@ -133,6 +216,17 @@ async def run_slide_design_agent(
         ppt_type = PowerPointType.WIDE_SCREEN if "16:9" in powerpoint_type else PowerPointType.STANDARD
         
         # 将大纲内容直接嵌入到 instruction 中
+        image_instruction = ""
+        if image_results:
+            image_instruction = """
+⚠️ 重要：markdown 文件中提供了可用图片素材，使用 {{img_N}} 占位符引用。
+- 必须使用 <img> 标签引用图片，例如：<img src="{{img_1}}" alt="描述">
+- ⛔ 严禁使用 CSS background-image: url() 引用图片（导出 PPTX 时会丢失）
+- 封面背景图请用绝对定位 <img> + 半透明遮罩 div 实现
+- 严禁编造任何图片 URL，只能使用 {{img_N}} 占位符
+- 内容页可在相关内容旁配图以增强视觉效果
+"""
+
         enhanced_instruction = f"""{topic}
 
 ⭐⭐⭐ 重要：请严格按照以下已生成的 PPT 大纲来创建幻灯片！⭐⭐⭐
@@ -145,7 +239,7 @@ async def run_slide_design_agent(
 - 不要修改大纲中的页面数量和结构
 - 不要添加大纲中没有的页面
 - 专注于视觉设计和排版，让内容更加美观
-"""
+{image_instruction}"""
         
         input_request = InputRequest(
             instruction=enhanced_instruction,

--- a/backend/services/search.py
+++ b/backend/services/search.py
@@ -4,8 +4,15 @@ PPTAgent 搜索服务模块
 提供 Tavily 和 DeepPresenter 搜索功能
 """
 
+import io
+import os
 import logging
+import asyncio
+from pathlib import Path
 from typing import List, Dict, Optional, AsyncGenerator
+
+import httpx
+from PIL import Image
 
 from utils.config import Config
 from services.llm import call_llm_api, call_llm_api_stream, extract_core_topic
@@ -163,6 +170,137 @@ async def execute_search(query: str, max_results: int = 10) -> List[Dict]:
     
     logger.warning(f"No search results for: {query}")
     return results
+
+
+async def _download_and_validate_image(
+    client: httpx.AsyncClient,
+    url: str,
+    description: str,
+    save_dir: Path,
+    index: int,
+) -> Optional[Dict]:
+    """下载单张图片并用 PIL 验证有效性，返回图片信息或 None"""
+    try:
+        resp = await client.get(url, timeout=15, follow_redirects=True)
+        if resp.status_code != 200:
+            return None
+
+        data = resp.content
+        img = Image.open(io.BytesIO(data))
+        width, height = img.size
+
+        # 过滤太小的图片（宽或高 < 100px）
+        if width < 100 or height < 100:
+            logger.debug(f"Image too small ({width}x{height}): {url}")
+            return None
+
+        # 保存到本地
+        ext = img.format.lower() if img.format else "jpg"
+        if ext == "jpeg":
+            ext = "jpg"
+        filename = f"img_{index}.{ext}"
+        local_path = save_dir / filename
+        local_path.write_bytes(data)
+
+        logger.info(f"Downloaded image {filename} ({width}x{height}) from {url[:80]}")
+        return {
+            "url": url,
+            "description": description or "",
+            "local_path": str(local_path),
+            "width": width,
+            "height": height,
+        }
+    except Exception as e:
+        logger.debug(f"Failed to download/validate image {url[:80]}: {e}")
+        return None
+
+
+async def search_and_download_images(
+    query: str,
+    workspace_dir: str,
+    max_images: int = 3,
+) -> List[Dict]:
+    """搜索图片并下载验证，返回有效图片列表
+
+    Args:
+        query: 搜索关键词
+        workspace_dir: 工作目录，图片保存到 workspace_dir/images/
+        max_images: 最多返回的有效图片数
+
+    Returns:
+        [{url, description, local_path, width, height}, ...]
+    """
+    if not Config.TAVILY_API_KEY:
+        logger.warning("Tavily API key not configured, skipping image search")
+        return []
+
+    try:
+        from tavily import TavilyClient
+
+        api_keys = [Config.TAVILY_API_KEY]
+        if Config.TAVILY_BACKUP:
+            api_keys.append(Config.TAVILY_BACKUP)
+
+        images_raw: List[Dict] = []
+        for api_key in api_keys:
+            try:
+                client = TavilyClient(api_key=api_key)
+                response = client.search(
+                    query=query,
+                    max_results=5,
+                    include_images=True,
+                    include_image_descriptions=True,
+                )
+                # Tavily returns images as list of {url, description} or list of strings
+                raw_images = response.get("images", [])
+                for item in raw_images:
+                    if isinstance(item, dict):
+                        images_raw.append({
+                            "url": item.get("url", ""),
+                            "description": item.get("description", ""),
+                        })
+                    elif isinstance(item, str):
+                        images_raw.append({"url": item, "description": ""})
+                logger.info(f"Tavily image search returned {len(images_raw)} images for: {query}")
+                break
+            except Exception as e:
+                logger.warning(f"Tavily image search failed with key: {str(e)[:50]}")
+                continue
+
+        if not images_raw:
+            return []
+
+        # 创建图片保存目录
+        save_dir = Path(workspace_dir) / "images"
+        save_dir.mkdir(parents=True, exist_ok=True)
+
+        # 为避免文件名冲突，统计已有图片数量（1-based: img_1, img_2, ...）
+        existing_count = len(list(save_dir.glob("img_*")))
+
+        # 并行下载并验证
+        async with httpx.AsyncClient() as http_client:
+            tasks = [
+                _download_and_validate_image(
+                    http_client,
+                    item["url"],
+                    item["description"],
+                    save_dir,
+                    existing_count + i + 1,
+                )
+                for i, item in enumerate(images_raw)
+            ]
+            results = await asyncio.gather(*tasks)
+
+        valid = [r for r in results if r is not None]
+        logger.info(f"Found {len(valid)} valid images for query: {query}")
+        return valid[:max_images]
+
+    except ImportError:
+        logger.error("Tavily package not installed, skipping image search")
+        return []
+    except Exception as e:
+        logger.error(f"Image search error: {e}")
+        return []
 
 
 async def stream_search_thinking(query: str, search_results: list, round_num: int, total_rounds: int) -> AsyncGenerator[str, None]:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,10 +5,10 @@ services:
       context: ./frontend
       dockerfile: Dockerfile
     ports:
-      - "3000:3000"
+      - "3001:3000"
     environment:
       - NODE_ENV=production
-      - VITE_API_URL=http://localhost:8000
+      - VITE_API_URL=http://localhost:8001
       # OAuth configuration (optional - leave empty if not using OAuth)
       - OAUTH_SERVER_URL=${OAUTH_SERVER_URL:-}
       - VITE_APP_ID=${VITE_APP_ID:-}
@@ -34,7 +34,7 @@ services:
 
       - postgres_data:/var/lib/postgresql/data
     ports:
-      - "5432:5432"
+      - "5435:5432"
     networks:
       - pptagent-network
     restart: unless-stopped
@@ -50,7 +50,7 @@ services:
       context: ./backend
       dockerfile: Dockerfile
     ports:
-      - "8000:8000"
+      - "8001:8000"
     env_file:
       - .env
     depends_on:


### PR DESCRIPTION
- 在 Stage 4 中并行执行 Tavily 图片搜索（include_images=True）
- 下载图片并用 PIL 验证有效性（最小 100px），保存到工作目录
- HTML 中使用 {{img_N}} 占位符引用图片，生成时替换为 base64 data URI
- 自动替换 AI 编造的假 URL（example.com 等）为真实图片
- 更新 SlideDesign 提示词：要求使用 <img> 标签，禁止 background-image CSS
- 封面页背景图改用绝对定位 <img> + 半透明遮罩方案