### PR TITLE
修复 PPTX 导出 问题

### DIFF
--- a/export_tool/app/services/pptx_service.py
+++ b/export_tool/app/services/pptx_service.py
@@ -8,9 +8,13 @@ import base64
 import json
 import logging
 import os
-from typing import Tuple
+import re
+from typing import Dict, List, Tuple
 from pathlib import Path
 import tempfile
+
+from urllib.request import Request, urlopen
+from urllib.error import URLError
 
 from playwright.async_api import TimeoutError as PlaywrightTimeoutError
 
@@ -21,6 +25,74 @@ from app.utils.icon_assets import get_material_symbols_base_url
 from app.utils.font_assets import resolve_font_configs
 
 logger = logging.getLogger(__name__)
+
+# Chrome-like UA so Google Fonts returns woff2 URLs
+_GFONTS_UA = (
+    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
+    "(KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+)
+_GFONTS_LINK_RE = re.compile(
+    r'<link[^>]+href=["\']'
+    r'(https?://fonts\.googleapis\.com/css2?\?[^"\']+)'
+    r'["\'][^>]*>',
+    re.IGNORECASE,
+)
+_FONT_FACE_RE = re.compile(
+    r"font-family:\s*['\"]?([^;'\"]+?)['\"]?\s*;.*?"
+    r"src:\s*url\(([^)]+)\)",
+    re.DOTALL,
+)
+
+
+def _fetch_google_fonts_css(html: str) -> Tuple[str, List[Dict[str, str]], str]:
+    """Extract Google Fonts <link> tags from HTML, fetch CSS server-side.
+
+    Returns:
+        (modified_html, font_configs, inline_css)
+        - modified_html: HTML with Google Fonts <link> tags removed
+        - font_configs: [{name, url}] for dom-to-pptx font embedding
+        - inline_css: fetched @font-face CSS to inject as same-origin <style>
+    """
+    links = _GFONTS_LINK_RE.findall(html)
+    if not links:
+        return html, [], ""
+
+    all_css_parts = []
+    font_configs: List[Dict[str, str]] = []
+    seen_urls: set = set()
+
+    for url in links:
+        # Skip icon fonts (Material Icons) — handled separately
+        if "family=Material" in url and "icon" in url.lower():
+            continue
+        try:
+            req = Request(url, headers={"User-Agent": _GFONTS_UA})
+            resp = urlopen(req, timeout=10)
+            css_text = resp.read().decode("utf-8")
+            all_css_parts.append(css_text)
+
+            # Extract font name + file URL from @font-face rules
+            for m in _FONT_FACE_RE.finditer(css_text):
+                name = m.group(1).strip()
+                font_url = m.group(2).strip().strip("'\"")
+                if font_url not in seen_urls:
+                    seen_urls.add(font_url)
+                    font_configs.append({"name": name, "url": font_url})
+        except URLError as e:
+            logger.warning(f"Google Fonts not available for {url} — {e.reason}")
+        except Exception as e:
+            logger.warning(f"Failed to fetch Google Fonts CSS: {url} — {e}")
+
+    # Remove all Google Fonts <link> tags from HTML (they'll be replaced by inline <style>)
+    modified_html = _GFONTS_LINK_RE.sub("", html)
+    inline_css = "\n".join(all_css_parts)
+
+    logger.info(
+        f"Fetched {len(all_css_parts)} Google Fonts stylesheet(s), "
+        f"{len(font_configs)} font file(s) discovered"
+    )
+    return modified_html, font_configs, inline_css
+
 
 def _get_dom_to_pptx_bundle_location() -> str:
     env_url = os.getenv("DOM_TO_PPTX_BUNDLE_URL")
@@ -119,7 +191,21 @@ async def generate_pptx_from_html(
             
             if not dom_info.get('hasExport'):
                 raise PptxGenerationError("dom-to-pptx.exportToPptx function not found")
-            
+
+            # Pre-process: fetch Google Fonts CSS server-side and strip <link> tags
+            processed_html, gfont_configs, gfont_css = _fetch_google_fonts_css(request.html)
+
+            # Inject Google Fonts @font-face CSS as same-origin <style> (before HTML)
+            if gfont_css:
+                await page.evaluate("""
+                    (css) => {
+                        const style = document.createElement('style');
+                        style.textContent = css;
+                        document.head.appendChild(style);
+                    }
+                """, gfont_css)
+                logger.info("Injected Google Fonts @font-face CSS as same-origin style")
+
             # Inject HTML content into the page
             logger.info("Injecting HTML content...")
             await page.evaluate("""
@@ -152,24 +238,6 @@ async def generate_pptx_from_html(
                     }
                 """, request.css)
             
-            # Inject global CSS to ensure text elements are on top layer in PPTX
-            logger.info("Injecting text layer z-index fix...")
-            await page.evaluate("""
-                () => {
-                    const textLayerStyle = document.createElement('style');
-                    textLayerStyle.textContent = `
-                        /* Auto-injected: Ensure text elements are on top layer for PPTX editing */
-                        h1, h2, h3, h4, h5, h6, p, span, a, li, ul, ol, td, th,
-                        div[class*="title"], div[class*="text"], div[class*="desc"],
-                        div[class*="label"], div[class*="badge"] {
-                            position: relative !important;
-                            z-index: 999 !important;
-                        }
-                    `;
-                    document.head.appendChild(textLayerStyle);
-                }
-            """)
-            
             # Enhance styles for better PPTX preservation
             logger.info("Enhancing styles for PPTX compatibility...")
             await page.evaluate("""
@@ -177,96 +245,78 @@ async def generate_pptx_from_html(
                     const styleEnhancement = document.createElement('style');
                     styleEnhancement.textContent = `
                         /* Auto-injected: Enhance style preservation in PPTX */
-                        
+
                         /* Preserve gradients */
                         [style*="linear-gradient"], [style*="radial-gradient"] {
                             background-size: 100% 100% !important;
                         }
-                        
-                        /* Enhance shadows for better visibility */
-                        [style*="box-shadow"] {
-                            box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15) !important;
-                        }
-                        
+
                         /* Ensure border-radius is preserved */
                         [style*="border-radius"] {
                             -webkit-border-radius: inherit;
                             -moz-border-radius: inherit;
                         }
-                        
+
                         /* Make table styles more robust */
                         table {
                             border-collapse: collapse !important;
                             width: 100% !important;
                         }
-                        
+
                         table th {
                             font-weight: 700 !important;
                         }
-                        
+
                         /* Ensure opacity values are preserved */
                         [style*="opacity"] {
                             -webkit-opacity: inherit;
                         }
-                        
+
                         /* Fix for images */
                         img {
                             max-width: 100%;
                             height: auto;
                         }
-                        
-                        /* Optimized text wrapping strategy */
-                        * {
-                            /* Keep Chinese words intact, only break when necessary */
+
+                        /* Chinese text wrapping — scoped to text elements only */
+                        p, li, td, th, dd, dt, figcaption, blockquote, label {
                             word-break: keep-all !important;
                             overflow-wrap: break-word !important;
-                            white-space: normal !important;
                         }
-                        
-                        /* Specific fixes for text containers */
-                        .item-text, .card-title, .card-content, .catalog-item, 
-                        p, div, span, h1, h2, h3, h4, h5, h6 {
-                            word-break: keep-all !important;
-                            overflow-wrap: break-word !important;
-                            white-space: normal !important;
-                        }
-                        
+
                         /* Allow breaking for very long words or URLs */
                         a, .url, .long-text {
                             word-break: break-all !important;
                         }
-                        
+
                         /* Preserve pre and code blocks */
                         pre, code {
                             white-space: pre-wrap !important;
                             word-break: keep-all !important;
                             overflow-wrap: break-word !important;
                         }
-                        
-                        /* Fix text layer z-index and positioning */
-                        .text-layer, .subtitle, .main-title, .page-title {
-                            position: relative !important;
-                            z-index: 10 !important;
-                        }
-                        
-                        /* Ensure proper spacing and prevent overlap */
-                        .subtitle {
-                            margin-top: 20px !important;
-                            clear: both !important;
-                        }
-                        
-                        /* Fix flex and grid layouts */
-                        .catalog-item, .card {
-                            display: flex !important;
-                            flex-wrap: wrap !important;
-                            align-items: flex-start !important;
+
+                        /* Fix Material Icons element width — force square to match glyph size */
+                        .material-icons, .material-symbols-outlined, .material-symbols-rounded {
+                            width: 1em !important;
+                            min-width: 1em !important;
+                            max-width: 1em !important;
+                            display: inline-flex !important;
+                            justify-content: center !important;
+                            align-items: center !important;
+                            overflow: hidden !important;
                         }
                     `;
                     document.head.appendChild(styleEnhancement);
                     console.log('✅ Style enhancements applied');
                 }
             """)
-            
+
+            # Wait for web fonts to load before measuring dimensions
+            logger.info("Waiting for fonts to load...")
+            await page.evaluate("document.fonts.ready")
+            await page.wait_for_timeout(200)
+
             # Wait for images and resources to load
             logger.info("Waiting for resources to load...")
             await page.evaluate("""
@@ -283,7 +333,7 @@ async def generate_pptx_from_html(
             await asyncio.sleep(1)  # Additional wait for rendering
             
             # Build options object for dom-to-pptx
-            auto_embed = request.options.autoEmbedFonts if request.options else False
+            auto_embed = request.options.autoEmbedFonts if request.options and request.options.autoEmbedFonts is not None else True
             options = {
                 "skipDownload": True,
                 "autoEmbedFonts": auto_embed,
@@ -324,6 +374,14 @@ async def generate_pptx_from_html(
                     for font in auto_fonts:
                         if font["name"] not in existing:
                             options.setdefault("fonts", []).append(font)
+
+            # Merge Google Fonts configs discovered by server-side fetch
+            if gfont_configs:
+                existing = {f["name"] for f in options.get("fonts", [])}
+                for font in gfont_configs:
+                    if font["name"] not in existing:
+                        options.setdefault("fonts", []).append(font)
+                logger.info(f"Added {len(gfont_configs)} Google Fonts to embedding list")
 
             # Inject @font-face rules to align browser layout with embedded fonts
             if options.get("fonts"):

--- a/export_tool/dom-to-pptx/src/index.js
+++ b/export_tool/dom-to-pptx/src/index.js
@@ -1224,6 +1224,7 @@ function prepareRenderItem(
   if (isText) {
     const textParts = [];
     let trimNextLeading = false;
+    let softBreakNext = false;
 
     if (pseudoBefore) {
       const pseudoStyle = window.getComputedStyle(node, '::before');
@@ -1234,9 +1235,15 @@ function prepareRenderItem(
     }
 
     node.childNodes.forEach((child, index) => {
-      // Handle <br> tags
+      // Skip icon elements — they are rendered separately as images
+      if (child.nodeType === 1 && isIconElement(child)) {
+        return;
+      }
+
+      // Handle <br> tags — use soft break (shift+enter) to stay within
+      // the same paragraph and preserve line-height spacing.
       if (child.tagName === 'BR') {
-        // 1. Trim trailing space from the *previous* text part to prevent double wrapping
+        // Trim trailing space from the *previous* text part to prevent double wrapping
         if (textParts.length > 0) {
           const lastPart = textParts[textParts.length - 1];
           if (lastPart.text && typeof lastPart.text === 'string') {
@@ -1244,9 +1251,8 @@ function prepareRenderItem(
           }
         }
 
-        textParts.push({ text: '', options: { breakLine: true } });
-
-        // 2. Signal to trim leading space from the *next* text part
+        // Signal the *next* text part to use a soft break before it
+        softBreakNext = true;
         trimNextLeading = true;
         return;
       }
@@ -1268,6 +1274,12 @@ function prepareRenderItem(
 
       if (textVal.length > 0) {
         const textOpts = getTextStyle(nodeStyle, config.scale);
+
+        // Apply pending soft break from a preceding <br>
+        if (softBreakNext) {
+          textOpts.softBreakBefore = true;
+          softBreakNext = false;
+        }
 
         // BUG FIX: Numbers 1 and 2 having background.
         // If this is a naked Text Node (nodeType 3), it inherits style from the parent container.
@@ -1295,6 +1307,12 @@ function prepareRenderItem(
       if (align === 'end') align = 'right';
       let valign = 'top';
       if (style.alignItems === 'center') valign = 'middle';
+      // Inherit vertical centering from parent flex container
+      const parentEl = node.parentElement;
+      if (parentEl) {
+        const parentStyle = window.getComputedStyle(parentEl);
+        if (parentStyle.display.includes('flex') && parentStyle.alignItems === 'center') valign = 'middle';
+      }
       if (style.justifyContent === 'center' && style.display.includes('flex')) align = 'center';
 
       const pt = parseFloat(style.paddingTop) || 0;
@@ -1468,7 +1486,6 @@ function prepareRenderItem(
         shapeType = pptx.ShapeType.roundRect;
         let r = radiusPx / minDimension;
         if (r > 0.5) r = 0.5;
-        if (minDimension < 100) r = r * 0.25; // Small size adjustment for small shapes
 
         shapeOpts.rectRadius = r;
       }

--- a/export_tool/dom-to-pptx/src/utils.js
+++ b/export_tool/dom-to-pptx/src/utils.js
@@ -363,7 +363,7 @@ export function parseColor(str) {
 
   // 2. Handle RGB/RGBA Output (standard) - Fast Path
   if (computed.startsWith('rgb')) {
-    const match = computed.match(/[\d.]+/g);
+    const match = computed.match(/(\d+(?:\.\d+)?)/g);
     if (match && match.length >= 3) {
       const r = parseInt(match[0]);
       const g = parseInt(match[1]);
@@ -406,6 +406,57 @@ export function getSoftEdges(filterStr, scale) {
   const match = filterStr.match(/blur\(([\d.]+)px\)/);
   if (match) return parseFloat(match[1]) * 0.75 * scale;
   return null;
+}
+
+/**
+ * Resolve CSS font-family to the actually-rendered font name for PPTX.
+ *
+ * Walks the comma-separated font stack and uses canvas measurement to
+ * determine which font is actually making a difference. For each candidate,
+ * it compares rendering WITH that font vs WITHOUT it (the rest of the stack).
+ * If removing it changes nothing, the font is not installed → skip it.
+ */
+const _genericFontMap = {
+  'serif': 'Times New Roman',
+  'sans-serif': 'Arial',
+  'monospace': 'Courier New',
+  'cursive': 'Comic Sans MS',
+  'fantasy': 'Impact',
+  'system-ui': 'Arial',
+  'ui-monospace': 'Courier New',
+};
+
+function resolveFontFace(fontFamily) {
+  const parts = fontFamily.split(',').map(f => f.trim().replace(/['"]/g, ''));
+  if (parts.length <= 1) return parts[0] || 'Arial';
+
+  try {
+    const canvas = document.createElement('canvas');
+    const ctx = canvas.getContext('2d');
+    const testStr = 'mmmmmmmmmmlli1|WwQq';
+
+    for (let i = 0; i < parts.length; i++) {
+      const face = parts[i].toLowerCase();
+      if (_genericFontMap[face]) return _genericFontMap[face];
+
+      // Build CSS font value: with this font vs without
+      const withFont = parts.slice(i).map(f => `"${f}"`).join(', ');
+      const withoutFont = parts.slice(i + 1).map(f => `"${f}"`).join(', ') || '"serif"';
+
+      ctx.font = `72px ${withFont}`;
+      const wWith = ctx.measureText(testStr).width;
+      ctx.font = `72px ${withoutFont}`;
+      const wWithout = ctx.measureText(testStr).width;
+
+      if (Math.abs(wWith - wWithout) > 0.5) {
+        // This font IS loaded and affecting rendering
+        return parts[i];
+      }
+      // Font not loaded — skip to next in stack
+    }
+  } catch (_) { /* fall through */ }
+
+  return parts[0] || 'Arial';
 }
 
 export function getTextStyle(style, scale) {
@@ -451,7 +502,7 @@ export function getTextStyle(style, scale) {
 
   return {
     color: colorObj.hex || '000000',
-    fontFace: style.fontFamily.split(',')[0].replace(/['"]/g, ''),
+    fontFace: resolveFontFace(style.fontFamily),
     fontSize: Math.floor(fontSizePx * 0.75 * scale),
     bold: parseInt(style.fontWeight) >= 600,
     italic: style.fontStyle === 'italic',
@@ -764,7 +815,7 @@ export function generateGradientSVG(w, h, bgString, radius, border) {
       // Handle RGBA/RGB for SVG compatibility
       let opacity = 1;
       if (color.includes('rgba')) {
-        const rgbaMatch = color.match(/[\d.]+/g);
+        const rgbaMatch = color.match(/(\d+(?:\.\d+)?)/g);
         if (rgbaMatch && rgbaMatch.length >= 4) {
           opacity = rgbaMatch[3];
           color = `rgb(${rgbaMatch[0]},${rgbaMatch[1]},${rgbaMatch[2]})`;


### PR DESCRIPTION
1. 标题 <br> 换行间距过大 — 改用软换行（softBreakBefore）
2. RGBA 透明度解析错误 — 修正正则匹配小数
3. CSS 注入过度破坏原始样式 — 删除/精简 !important 注入
4. 徽章圆角丢失 — 移除小元素圆角缩减逻辑
5. icon ligature 文字重复 — 文本提取时跳过图标元素
6. Material Icons 宽度过大 — 强制 width:1em
7. flex 居中文字偏上 — 增加父元素 align-items 检查
8. 字体未嵌入 — 服务端获取 Google Fonts CSS 绕过 CORS + canvas 字体检测
9. 背景图片丢失 — 提示词改用 <img> 标签（已在 SlideDesign.yaml 中处理）